### PR TITLE
Update volume size to 100

### DIFF
--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -61,7 +61,7 @@ head_node:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
-              VolumeSize: 50
+              VolumeSize: 100
 
     # Additional options in the boto docs.
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Current volume size of 50 in AWS autoscalar isn't large enough. Requires 75, proposed 100.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
